### PR TITLE
nth-prime: speed up example.awk

### DIFF
--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "IsaacG"
   ],
+  "contributors": [
+    "glennj"
+  ],
   "files": {
     "solution": [
       "nth-prime.awk"

--- a/exercises/practice/nth-prime/.meta/example.awk
+++ b/exercises/practice/nth-prime/.meta/example.awk
@@ -7,22 +7,28 @@ BEGIN {
         print(2)
         exit(0)
     }
+
+    primes[1] = 2
     count = 1
     candidate = 1
+
     while (count < n) {
-        candidate += 2
-        is_prime = 1
-        for (i in primes) {
-            if (candidate % i == 0) {
-                is_prime = 0
-                break
+        while (1) {
+            candidate += 2
+            is_prime = 1
+            i = 1
+            while (primes[i] <= sqrt(candidate)) {
+                if (candidate % primes[i] == 0) {
+                    is_prime = 0
+                    break
+                }
+                i++
             }
+            if (is_prime) break
         }
-        if (is_prime) {
-            primes[candidate] = 1
-            count++
-        }
+        primes[++count] = candidate
     }
-    print candidate
+
+    print primes[n]
 }
 

--- a/exercises/practice/nth-prime/test-nth-prime.bats
+++ b/exercises/practice/nth-prime/test-nth-prime.bats
@@ -31,7 +31,7 @@ load bats-extra
 
 @test "big prime" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run gawk -f nth-prime.awk -v n=10001 -M
+    run gawk -f nth-prime.awk -v n=10001
     assert_success
     assert_output "104743"
 }


### PR DESCRIPTION
This alters the `for` loop that tests for primality using the currently known primes.

Things that speed it up:
* it's testing primes from smallest to largest, so it's finding non-primes quicker (e.g. more candidates will be divisible by 3 than by 17)
* it's stopping when the current prime > sqrt(candidate), reducing the number of tests required.
* (this may be slight) I'm using a numerically indexed array, so there's no sorting required for array traversal
    * I did try a version where the primes were the array indices, and used PROCINFO["sorted_in"] but it was still slow.


closes #112 

