### PR TITLE
put actual help in the shared/.docs/help.md file instead of just a link

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,6 +1,19 @@
 # Help
 
-Please see the [AWK installation][installation] document on the Exercism website.
-In addition to installation instructions, several links to help resources are listed.
+Places to look for help for AWK questions:
 
-[installation]: https://exercism.org/docs/tracks/awk/installation
+* [Stack Overflow `awk` tag][so].
+* check the Resources section of the [Stack Overflow `awk` tag into page][so-info].
+* the [exercism/awk][gitter-awk] gitter chat room.
+* the [exercism/support][gitter-support] gitter chat room.
+* raise an issue at the [exercism/awk][github] Github repository.
+* IRC: `irc://irc.liberachat.net/#awk`, `irc://irc.liberachat.net/#exercism`
+    * see [Libera.chat][libera] if you're unfamiliar with IRC.
+
+
+[so]: https://stackoverflow.com/tags/awk
+[so-info]: https://stackoverflow.com/tags/awk/info
+[gitter-awk]: https://gitter.im/exercism/awk
+[gitter-support]: https://gitter.im/exercism/support
+[github]: https://github.com/exercism/awk
+[libera]: https://libera.chat


### PR DESCRIPTION
This **copies** the resources from the INSTALLATION.md file to here.

The `help.md` file is folded into the `HELP.md` file in the downloaded exercise folder.