### PR TITLE
Sync recent exercise updates

### DIFF
--- a/exercises/practice/atbash-cipher/.docs/instructions.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.md
@@ -21,6 +21,7 @@ been an issue in the cipher's time.
 Ciphertext is written out in groups of fixed length, the traditional group size
 being 5 letters, leaving numbers unchanged, and punctuation is excluded.
 This is to make it harder to guess things based on word boundaries.
+All text will be encoded as lowercase letters.
 
 ## Examples
 

--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -20,7 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
+The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -80,3 +80,9 @@ description = "666 is DCLXVI"
 
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/test-roman-numerals.bats
+++ b/exercises/practice/roman-numerals/test-roman-numerals.bats
@@ -134,6 +134,21 @@ load bats-extra
     assert_output "MMM"
 }
 
+@test "3001 is three MMMI" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f roman-numerals.awk <<< 3001
+    assert_success
+    assert_output "MMMI"
+}
+
+@test "3999 is three MMMCMXCIX" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f roman-numerals.awk <<< 3999
+    assert_success
+    assert_output "MMMCMXCIX"
+}
+
+
 # testing numbers with all roman numerals below a threshold
 
 @test "16 is XVI" {

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
@@ -22,6 +29,9 @@ description = "slices of a long series"
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
+
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"

--- a/exercises/practice/series/test-series.bats
+++ b/exercises/practice/series/test-series.bats
@@ -59,6 +59,14 @@ load bats-extra
     assert_output --partial "$expected"
 }
 
+@test "slice length is way too large" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    expected="invalid length"
+    run gawk -f series.awk -v len=42 <<< 12345
+    assert_failure
+    assert_output --partial "$expected"
+}
+
 @test "slice length cannot be zero" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="invalid length"

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,60 +1,73 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
-description = "all sides are equal"
+description = "equilateral triangle -> all sides are equal"
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
-description = "any side is unequal"
+description = "equilateral triangle -> any side is unequal"
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
-description = "no sides are equal"
+description = "equilateral triangle -> no sides are equal"
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
-description = "all zero sides is not a triangle"
+description = "equilateral triangle -> all zero sides is not a triangle"
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
-description = "sides may be floats"
+description = "equilateral triangle -> sides may be floats"
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
-description = "last two sides are equal"
+description = "isosceles triangle -> last two sides are equal"
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
-description = "first two sides are equal"
+description = "isosceles triangle -> first two sides are equal"
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
-description = "first and last sides are equal"
+description = "isosceles triangle -> first and last sides are equal"
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
-description = "equilateral triangles are also isosceles"
+description = "isosceles triangle -> equilateral triangles are also isosceles"
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
-description = "no sides are equal"
+description = "isosceles triangle -> no sides are equal"
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
-description = "first triangle inequality violation"
+description = "isosceles triangle -> first triangle inequality violation"
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
-description = "second triangle inequality violation"
+description = "isosceles triangle -> second triangle inequality violation"
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
-description = "third triangle inequality violation"
+description = "isosceles triangle -> third triangle inequality violation"
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
-description = "sides may be floats"
+description = "isosceles triangle -> sides may be floats"
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
-description = "no sides are equal"
+description = "scalene triangle -> no sides are equal"
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
-description = "all sides are equal"
+description = "scalene triangle -> all sides are equal"
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
-description = "two sides are equal"
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
-description = "may not violate triangle inequality"
+description = "scalene triangle -> may not violate triangle inequality"
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
-description = "sides may be floats"
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/triangle/test-triangle.bats
+++ b/exercises/practice/triangle/test-triangle.bats
@@ -119,9 +119,23 @@ load bats-extra
   assert_output "false"
 }
 
-@test "two sides are equal" {
+@test "first and second sides are equal" {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f triangle.awk -v type=scalene <<< "4 4 3"
+  assert_success
+  assert_output "false"
+}
+
+@test "first and third sides are equal" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f triangle.awk -v type=scalene <<< "3 4 3"
+  assert_success
+  assert_output "false"
+}
+
+@test "second and third sides are equal" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f triangle.awk -v type=scalene <<< "4 3 3"
   assert_success
   assert_output "false"
 }

--- a/exercises/practice/variable-length-quantity/.docs/instructions.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.md
@@ -5,7 +5,7 @@ Implement variable length quantity encoding and decoding.
 The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
 
 In short, the goal of this encoding is to encode integer values in a way that would save bytes.
-Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte).
+Only the first 7 bits of each byte are significant (right-justified; sort of like an ASCII byte).
 So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
 Of course, you will have a variable number of bytes depending upon your integer.
 To indicate which is the last byte of the series, you leave bit #7 clear.

--- a/exercises/practice/word-count/.docs/instructions.md
+++ b/exercises/practice/word-count/.docs/instructions.md
@@ -12,7 +12,7 @@ When counting words you can assume the following rules:
 
 1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
 2. The count is _unordered_; the tests will ignore how words and counts are ordered
-3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are regarded as spaces
 4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
 
 For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:


### PR DESCRIPTION
```text
$ bin/configlet sync 
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] docs: instructions unsynced: atbash-cipher
[warn] docs: instructions unsynced: roman-numerals
[warn] docs: instructions unsynced: variable-length-quantity
[warn] docs: instructions unsynced: word-count
[warn] roman-numerals: missing 2 test cases
       - 3001 is MMMI (3bc4b41c-c2e6-49d9-9142-420691504336)
       - 3999 is MMMCMXCIX (4e18e96b-5fbb-43df-a91b-9cb511fe0856)
[warn] series: missing 1 test case
       - slice length is way too large (d7957455-346d-4e47-8e4b-87ed1564c6d7)
[warn] triangle: missing 2 test cases
       - scalene triangle -> first and third sides are equal (3da23a91-a166-419a-9abf-baf4868fd985)
       - scalene triangle -> second and third sides are equal (b6a75d98-1fef-4c42-8e9a-9db854ba0a4d)
[warn] some exercises have unsynced docs
[warn] some exercises are missing test cases
```