### PR TITLE
Add 2 new tests: big numbers

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/example.awk
+++ b/exercises/practice/armstrong-numbers/.meta/example.awk
@@ -1,17 +1,15 @@
 # These variables are initialized on the command line (using '-v'):
 # - num
 
-function is_armstrong(n,    m, len, sum) {
-    m = n
-    len = length(n)
-    sum = 0
-    while (n > 0) {
-        sum += (n % 10) ^ len
-        n = int(n / 10)
+function is_armstrong(num,    len, sum) {
+    len = split(num, digits, "")
+    for (i=1; i <= len; i++) {
+        sum += digits[i] ^ len
     }
-    return sum == m
+    return sum == num
 }
 
 BEGIN {
     print is_armstrong(num) ? "true" : "false"
 }
+

--- a/exercises/practice/armstrong-numbers/test-armstrong-numbers.bats
+++ b/exercises/practice/armstrong-numbers/test-armstrong-numbers.bats
@@ -3,63 +3,81 @@ load bats-extra
 
 @test 'Zero is Armstrong numbers' {
   # [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=0 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=0
   assert_success
   assert_output "true"
 }
 
 @test 'Single digits are Armstrong numbers' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=5 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=5
   assert_success
   assert_output "true"
 }
 
 @test 'There are no two digit Armstrong numbers' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=10 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=10
   assert_success
   assert_output "false"
 }
 
 @test 'A three digit number that is an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=153 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=153
   assert_success
   assert_output "true"
 }
 
 @test 'A three digit number that is not an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=100 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=100
   assert_success
   assert_output "false"
 }
 
 @test 'A four digit number that is an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=9474 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=9474
   assert_success
   assert_output "true"
 }
 
 @test 'A four digit number that is not an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=9475 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=9475
   assert_success
   assert_output "false"
 }
 
 @test 'A seven digit number that is an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=9926315 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=9926315
   assert_success
   assert_output "true"
 }
 
 @test 'A seven digit number that is not an Armstrong number' {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run gawk -f armstrong-numbers.awk -v num=9926314 <<< ""
+  run gawk -f armstrong-numbers.awk -v num=9926314
   assert_success
   assert_output "false"
+}
+
+# The next 2 tests require the -M option to handle big numbers.
+# Refer to the instructions of the Grains exercise:
+#   https://exercism.org/tracks/awk/exercises/grains
+
+@test "Armstrong number containing seven zeroes" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -M -f armstrong-numbers.awk -v num=186709961001538790100634132976990
+  assert_success
+  assert_output "true"
+}
+
+@test "The largest and last Armstrong number" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -M -f armstrong-numbers.awk -v num=115132219018763992565095597973971522401
+  assert_success
+  assert_output "true"
 }


### PR DESCRIPTION
This required a reimplementation to avoid arithmetic errors, even with big number support:
```sh
$ echo 18670996100153879010063413297699 | gawk -M '{print $1; print int($1/10)}'
18670996100153879010063413297699
1867099610015387799844860985344

$ gawk --version
GNU Awk 5.1.0, API: 3.0 (GNU MPFR 4.1.0, GNU MP 6.2.1)
```

Also removed the useless here-strings