### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Since I (@glennj) have spent a lot of time building up the bash track, I'll stea
 
 ## Support
 
-[![Join the chat at https://gitter.im/exercism/awk](https://badges.gitter.im/exercism/awk.svg)](https://gitter.im/exercism/awk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Get help on the [Exercism forum][forum].
 
-
+[forum]: https://forum.exercism.org/
 [b0rk-tweet]: https://twitter.com/b0rk/status/1000604334026055681?s=20&t=6-hkY0dxnID7y05XvJkEsg
 [b0rk-image]: https://pbs.twimg.com/media/DeLcVfSWAAAw6OZ?format=jpg&name=small
 [gawk]: https://www.gnu.org/software/gawk/ 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -65,8 +65,6 @@ Places to look for help for AWK questions:
 
 * [Stack Overflow `awk` tag][so].
 * check the Resources section of the [Stack Overflow `awk` tag into page][so-info].
-* the [exercism/awk][gitter-awk] gitter chat room.
-* the [exercism/support][gitter-support] gitter chat room.
 * raise an issue at the [exercism/awk][github] Github repository.
 * IRC: `irc://irc.liberachat.net/#awk`, `irc://irc.liberachat.net/#exercism`
     * see [Libera.chat][libera] if you're unfamiliar with IRC.
@@ -77,7 +75,5 @@ Places to look for help for AWK questions:
 [brew]: https://brew.sh/
 [so]: https://stackoverflow.com/tags/awk
 [so-info]: https://stackoverflow.com/tags/awk/info
-[gitter-awk]: https://gitter.im/exercism/awk
-[gitter-support]: https://gitter.im/exercism/support
 [github]: https://github.com/exercism/awk
 [libera]: https://libera.chat

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -4,8 +4,6 @@ Places to look for help for AWK questions:
 
 * [Stack Overflow `awk` tag][so].
 * check the Resources section of the [Stack Overflow `awk` tag into page][so-info].
-* the [exercism/awk][gitter-awk] gitter chat room.
-* the [exercism/support][gitter-support] gitter chat room.
 * raise an issue at the [exercism/awk][github] Github repository.
 * IRC: `irc://irc.liberachat.net/#awk`, `irc://irc.liberachat.net/#exercism`
     * see [Libera.chat][libera] if you're unfamiliar with IRC.
@@ -13,7 +11,5 @@ Places to look for help for AWK questions:
 
 [so]: https://stackoverflow.com/tags/awk
 [so-info]: https://stackoverflow.com/tags/awk/info
-[gitter-awk]: https://gitter.im/exercism/awk
-[gitter-support]: https://gitter.im/exercism/support
 [github]: https://github.com/exercism/awk
 [libera]: https://libera.chat


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
