### PR TITLE
Fix typo in LEARNING.md

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,6 +1,6 @@
 # Learning
 
-For a quick overview of the lanaguage, refer to the [awk info page][so] on Stack Overflow.
+For a quick overview of the language, refer to the [awk info page][so] on Stack Overflow.
 
 Some other learning resources:
 


### PR DESCRIPTION
- Fix typo in the word `language` that was `lanaguage`