### PR TITLE
update validate scripts

### DIFF
--- a/bin/validate_exercises
+++ b/bin/validate_exercises
@@ -8,7 +8,15 @@ set -o nounset
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
-for exercise in exercises/*/*; do
+while read -r exercise; do
     bin/validate_one_exercise "$exercise"
     echo
-done
+done < <(
+    jq -r '
+        .exercises  as $exs 
+        | ["concept","practice"][] 
+        | . as $type 
+        | $exs[$type][] 
+        | "exercises/\($type)/\(.slug)"
+    ' config.json
+)

--- a/bin/validate_one_exercise
+++ b/bin/validate_one_exercise
@@ -22,26 +22,34 @@ stub=$(jq -r '.files.solution[0]' "$config")
 tests=$(jq -r '.files.test[0]' "$config")
 [[ -f ${tests} ]] || die "Missing tests file for $exercise"
 
-solution=$(jq -r '.files.example[0]' "$config")
+solution=$(jq -r '.files.example[0] // .files.exemplar[0]' "$config")
 [[ -f ${solution} ]] || die "Missing solution file for $exercise"
 
+# this is usually empty but might have multiple files in it
+readarray -t editor_files < <(jq -r '.files.editor[]?' "$config")
+
 # hello-world has no skips
-if [[ ${exercise} != "hello-world" ]]; then
+# neither do concept exercises
+if [[ ${exercise} != "hello-world" ]] && ! [[ $PWD =~ exercises/concept/ ]]; then
     # a PCRE: the `\Q...\E` defines a literal segment
     skip_re='^\s*#+\s*\Q[[ $BATS_RUN_SKIPPED == "true" ]] || skip\E$'
-    num_skip_comments=$(grep -cP "${skip_re}" "${tests}")
+    num_skip_comments=$(grep -cP "${skip_re}" "${tests}") || :
     (( num_skip_comments == 1 )) || die "There should be exactly one commented skip directive in ${tests}"
 fi
 
 echo "Processing ${exercise}"
 
 cleanup() {
-    git checkout "${stub}"
+    rm -rf "$dir"
 }
 trap cleanup EXIT
 
 # Create implementation file from example
-cp "${solution}" "${stub}"
+dir=$(mktemp -d)
+cp "${solution}" "${dir}/${stub}"
+cp "${tests}" "${dir}/${tests}"
+cp bats-extra.bash "${editor_files[@]}" "${dir}"
 
 # Run the tests
+cd "${dir}"
 BATS_RUN_SKIPPED=true bats "${tests}"


### PR DESCRIPTION
This is a tactic I picked up on the wren track, and I used in jq. To test an exercise, copy the necessary files into a temp dir. This is quite useful when developing, don't accidentally lose edits with an ill-timed "git checkout".