### PR TITLE
Sync largest-series-product docs with problem-specifications

### DIFF
--- a/exercises/practice/largest-series-product/.docs/instructions.md
+++ b/exercises/practice/largest-series-product/.docs/instructions.md
@@ -1,19 +1,26 @@
 # Instructions
 
-Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.
+Your task is to look for patterns in the long sequence of digits in the encrypted signal.
 
-For example, for the input `'1027839564'`, the largest product for a series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
+The technique you're going to use here is called the largest series product.
 
-Note that these series are only required to occupy *adjacent positions* in the input; the digits need not be *numerically consecutive*.
+Let's define a few terms, first.
 
-For the input `'73167176531330624919225119674426574742355349194934'`,
-the largest product for a series of 6 digits is 23520.
+- **input**: the sequence of digits that you need to analyze
+- **series**: a sequence of adjacent digits (those that are next to each other) that is contained within the input
+- **span**: how many digits long each series is
+- **product**: what you get when you multiply numbers together
 
-For a series of zero digits, you need to return the empty product (the result of multiplying no numbers), which is 1.
+Let's work through an example, with the input `"63915"`.
 
-~~~~exercism/advanced
-You do not need to understand why the empty product is 1 to solve this problem,
-but in case you are interested, here is an informal argument: if we split a list of numbers `A` into two new lists `B` and `C`, then we expect `product(A) == product(B) * product(C)` because we don't expect the order that you multiply things to matter; now if we split a list containing only the number 3 into the empty list and a list containing the number 3 then the product of the empty list has to be 1 for `product([3]) == product([]) * product([3])` to be true.
-
-The same kind of argument justifies why the sum of no numbers is 0.
-~~~~
+- To form a series, take adjacent digits in the original input.
+- If you are working with a span of `3`, there will be three possible series:
+  - `"639"`
+  - `"391"`
+  - `"915"`
+- Then we need to calculate the product of each series:
+  - The product of the series `"639"` is 162 (`6 × 3 × 9 = 162`)
+  - The product of the series `"391"` is 27 (`3 × 9 × 1 = 27`)
+  - The product of the series `"915"` is 45 (`9 × 1 × 5 = 45`)
+- 162 is bigger than both 27 and 45, so the largest series product of `"63915"` is from the series `"639"`.
+  So the answer is **162**.

--- a/exercises/practice/largest-series-product/.docs/introduction.md
+++ b/exercises/practice/largest-series-product/.docs/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+You work for a government agency that has intercepted a series of encrypted communication signals from a group of bank robbers.
+The signals contain a long sequence of digits.
+Your team needs to use various digital signal processing techniques to analyze the signals and identify any patterns that may indicate the planning of a heist.

--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -41,9 +41,11 @@ description = "rejects span longer than string length"
 
 [06bc8b90-0c51-4c54-ac22-3ec3893a079e]
 description = "reports 1 for empty string and empty product (0 span)"
+include = false
 
 [3ec0d92e-f2e2-4090-a380-70afee02f4c0]
 description = "reports 1 for nonempty string and empty product (0 span)"
+include = false
 
 [6d96c691-4374-4404-80ee-2ea8f3613dd4]
 description = "rejects empty string and nonzero span"

--- a/exercises/practice/largest-series-product/test-largest-series-product.bats
+++ b/exercises/practice/largest-series-product/test-largest-series-product.bats
@@ -64,36 +64,6 @@ load bats-extra
     assert_output "0"
 }
 
-# There may be some confusion about whether this should be 1 or error.
-# The reasoning for it being 1 is this:
-# There is one 0-character string contained in the empty string.
-# That's the empty string itself.
-# The empty product is 1 (the identity for multiplication).
-# Therefore LSP('', 0) is 1.
-# It's NOT the case that LSP('', 0) takes max of an empty list.
-# So there is no error.
-# Compare against LSP('123', 4):
-# There are zero 4-character strings in '123'.
-# So LSP('123', 4) really DOES take the max of an empty list.
-# So LSP('123', 4) errors and LSP('', 0) does NOT.
-
-@test "reports 1 for empty string and empty product (0 span)" {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run gawk -f largest-series-product.awk <<< ",0"
-    assert_success
-    assert_output "1"
-}
-
-# As above, there is one 0-character string in '123'.
-# So again no error. It's the empty product, 1.
-
-@test "reports 1 for nonempty string and empty product (0 span)" {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run gawk -f largest-series-product.awk <<< "123,0"
-    assert_success
-    assert_output "1"
-}
-
 # error cases
 
 @test "rejects span longer than string length" {


### PR DESCRIPTION
The largest-series-product exercise has been overhauled as part of a project to make practice exercises more consistent and friendly.

For more context, please see the discussion in the forum, as well as the pull request that updated the exercise in the problem-specifications repository:

- https://forum.exercism.org/t/new-project-making-practice-exercises-more-consistent-and-human-across-exercism/3943
- https://github.com/exercism/problem-specifications/pull/2246 


Note that we have deprecated and removed two test cases that deal with the multiplicative identity (also referred to as an empty product). By doing this we were able to avoid talking about this at all, which makes this exercise much more approachable.

----

If you approve this pull request, I will eventually merge it. However, if you are happy with this change **please merge the pull request**, as it will get the changes into the hands of the students much more quickly.

If this pull request contradicts the exercise on your track, **please add a review with _request changes_**. This will block the pull request from getting merged.

Otherwise, as discussed in the forum post linked to above, we aim to take an optimistic merging approach.

If you wish to suggest tweaks to these changes, please open a pull request to the exercism/problem-specifications repository to discuss, so that everyone who has an interest in the shared exercise descriptions can participate.

