### PR TITLE
The width of grades can exceed a single character and may even be non-numeric.

### DIFF
--- a/exercises/practice/grade-school/test-grade-school.bats
+++ b/exercises/practice/grade-school/test-grade-school.bats
@@ -106,8 +106,8 @@ END_INPUT
 
     run gawk -f grade-school.awk -v action=roster << END_INPUT
 Peter,2
-Anna,1
-Barb,1
+Anna,10
+Barb,AB
 Zoe,2
 Alex,2
 Jim,3
@@ -115,7 +115,7 @@ Charlie,1
 END_INPUT
 
     assert_success
-    assert_output "Anna,Barb,Charlie,Alex,Peter,Zoe,Jim"
+    assert_output "Charlie,Alex,Peter,Zoe,Jim,Anna,Barb"
 }
 
 @test "Grade is empty if no students in the roster" {


### PR DESCRIPTION
While mentored by [Filbo](https://exercism.org/profiles/filbo), he revealed to me the idea of generalizing the code to accept grades with width more than one character. I checked it to accept also non-numeric grade values. I adjusted my code to pass this test, and I changed one of the testes to do this kind of test.