### PR TITLE
Update test-all-your-base.bats

### DIFF
--- a/exercises/practice/all-your-base/.meta/example.awk
+++ b/exercises/practice/all-your-base/.meta/example.awk
@@ -21,7 +21,10 @@ BEGIN {
         base = ibase ^ (NF - i)
         val += $i * base
     }
-    
+
+    # Handle default for no looping (0 value) or no entry (empty in empty out)
+    if (val == 0 && NF > 0) parts[0] = 0
+
     # Convert from decimal to obase words.
     i = 0
     while (val) {

--- a/exercises/practice/all-your-base/test-all-your-base.bats
+++ b/exercises/practice/all-your-base/test-all-your-base.bats
@@ -70,14 +70,14 @@ load bats-extra
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f all-your-base.awk -v ibase=10 -v obase=2 <<< "0"
     assert_success
-    assert_output "0" # 0 is 0 in any base
+    assert_output "0"
 }
 
 @test 'multiple zeroes' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f all-your-base.awk -v ibase=10 -v obase=2 <<< "0 0 0"
     assert_success
-    assert_output "0"  # 0 is 0 in any base
+    assert_output "0"
 }
 
 @test 'leading zeros' {

--- a/exercises/practice/all-your-base/test-all-your-base.bats
+++ b/exercises/practice/all-your-base/test-all-your-base.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 load bats-extra
 
-# local version: 2.3.0.0
+# local version: 2.3.0.1
 
 @test 'single bit to one decimal' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
@@ -70,14 +70,14 @@ load bats-extra
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f all-your-base.awk -v ibase=10 -v obase=2 <<< "0"
     assert_success
-    assert_output ""
+    assert_output "0" # 0 is 0 in any base
 }
 
 @test 'multiple zeroes' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f all-your-base.awk -v ibase=10 -v obase=2 <<< "0 0 0"
     assert_success
-    assert_output ""
+    assert_output "0"  # 0 is 0 in any base
 }
 
 @test 'leading zeros' {


### PR DESCRIPTION
0 should not be converted to the empty string when converting between bases. 0 should remain 0.