### PR TITLE
Add Killer Sudoku Helper exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -475,6 +475,14 @@
         "difficulty": 4
       },
       {
+        "slug": "killer-sudoku-helper",
+        "name": "Killer Sudoku Helper",
+        "uuid": "dcb58258-8510-4980-8e6f-6d8ff136eb83",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "slug": "kindergarten-garden",
         "name": "Kindergarten Garden",
         "uuid": "a556b380-1535-49e3-8299-b3a1ba31a2c7",

--- a/exercises/practice/killer-sudoku-helper/.docs/instructions.md
+++ b/exercises/practice/killer-sudoku-helper/.docs/instructions.md
@@ -1,0 +1,85 @@
+# Instructions
+
+A friend of yours is learning how to solve Killer Sudokus (rules below) but struggling to figure out which digits can go in a cage.
+They ask you to help them out by writing a small program that lists all valid combinations for a given cage, and any constraints that affect the cage.
+
+To make the output of your program easy to read, the combinations it returns must be sorted.
+
+## Killer Sudoku Rules
+
+- [Standard Sudoku rules][sudoku-rules] apply.
+- The digits in a cage, usually marked by a dotted line, add up to the small number given in the corner of the cage.
+- A digit may only occur once in a cage.
+
+For a more detailed explanation, check out [this guide][killer-guide].
+
+## Example 1: Cage with only 1 possible combination
+
+In a 3-digit cage with a sum of 7, there is only one valid combination: 124.
+
+- 1 + 2 + 4 = 7
+- Any other combination that adds up to 7, e.g. 232, would violate the rule of not repeating digits within a cage.
+
+![Sudoku grid, with three killer cages that are marked as grouped together.
+The first killer cage is in the 3×3 box in the top left corner of the grid.
+The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 5.
+The numbers are highlighted in red to indicate a mistake.
+The second killer cage is in the central 3×3 box of the grid.
+The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 4.
+None of the numbers in this cage are highlighted and therefore don't contain any mistakes.
+The third killer cage follows the outside corner of the central 3×3 box of the grid.
+It is made up of the following three cells: the top left cell of the cage contains a 2, highlighted in red, and a cage sum of 7.
+The top right cell of the cage contains a 3.
+The bottom right cell of the cage contains a 2, highlighted in red. All other cells are empty.][one-solution-img]
+
+## Example 2: Cage with several combinations
+
+In a 2-digit cage with a sum 10, there are 4 possible combinations:
+
+- 19
+- 28
+- 37
+- 46
+
+![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled.
+Each continguous two rows form a killer cage and are marked as grouped together.
+From top to bottom: first group is a cell with value 1 and a pencil mark indicating a cage sum of 10, cell with value 9.
+Second group is a cell with value 2 and a pencil mark of 10, cell with value 8.
+Third group is a cell with value 3 and a pencil mark of 10, cell with value 7.
+Fourth group is a cell with value 4 and a pencil mark of 10, cell with value 6.
+The last cell in the column is empty.][four-solutions-img]
+
+## Example 3: Cage with several combinations that is restricted
+
+In a 2-digit cage with a sum 10, where the column already contains a 1 and a 4, there are 2 possible combinations:
+
+- 28
+- 37
+
+19 and 46 are not possible due to the 1 and 4 in the column according to standard Sudoku rules.
+
+![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled.
+The first row contains a 4, the second is empty, and the third contains a 1.
+The 1 is highlighted in red to indicate a mistake.
+The last 6 rows in the column form killer cages of two cells each.
+From top to bottom: first group is a cell with value 2 and a pencil mark indicating a cage sum of 10, cell with value 8.
+Second group is a cell with value 3 and a pencil mark of 10, cell with value 7.
+Third group is a cell with value 1, highlighted in red, and a pencil mark of 10, cell with value 9.][not-possible-img]
+
+## Trying it yourself
+
+If you want to give an approachable Killer Sudoku a go, you can try out [this puzzle][clover-puzzle] by Clover, featured by [Mark Goodliffe on Cracking The Cryptic on the 21st of June 2021][goodliffe-video].
+
+You can also find Killer Sudokus in varying difficulty in numerous newspapers, as well as Sudoku apps, books and websites.
+
+## Credit
+
+The screenshots above have been generated using [F-Puzzles.com](https://www.f-puzzles.com/), a Puzzle Setting Tool by Eric Fox.
+
+[sudoku-rules]: https://masteringsudoku.com/sudoku-rules-beginners/
+[killer-guide]: https://masteringsudoku.com/killer-sudoku/
+[one-solution-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example1.png
+[four-solutions-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example2.png
+[not-possible-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example3.png
+[clover-puzzle]: https://app.crackingthecryptic.com/sudoku/HqTBn3Pr6R
+[goodliffe-video]: https://youtu.be/c_NjEbFEeW0?t=1180

--- a/exercises/practice/killer-sudoku-helper/.meta/config.json
+++ b/exercises/practice/killer-sudoku-helper/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "rabestro"
+  ],
+  "files": {
+    "solution": [
+      "killer-sudoku-helper.awk"
+    ],
+    "test": [
+      "test-killer-sudoku-helper.bats"
+    ],
+    "example": [
+      ".meta/example.awk"
+    ]
+  },
+  "blurb": "Write a tool that makes it easier to solve Killer Sudokus",
+  "source": "Created by Sascha Mann, Jeremy Walker, and BethanyG for the Julia track on Exercism.",
+  "source_url": "https://github.com/exercism/julia/pull/413"
+}

--- a/exercises/practice/killer-sudoku-helper/.meta/example.awk
+++ b/exercises/practice/killer-sudoku-helper/.meta/example.awk
@@ -2,15 +2,17 @@ BEGIN {
     MaxDigit = 9
 }
 {
+    cageSum = $1
+    cageSize = $2
     for (i = 3; i <= NF; ++i) {
         ExcludedDigits[$i] = 1
     }
     NF = 0
-    generate_recursive(1, $1, $2)
+    generate_recursive(1, cageSum, cageSize)
 }
 
 function generate_recursive(currentStartDigit, remainingSum, remainingSize,   maxPossibleFirstDigit,digit) {
-    ++NF
+    NF++
     if (remainingSize == 1) {
         if (currentStartDigit <= remainingSum && remainingSum <= MaxDigit && !(remainingSum in ExcludedDigits)) {
             $NF = remainingSum
@@ -25,5 +27,5 @@ function generate_recursive(currentStartDigit, remainingSum, remainingSize,   ma
             generate_recursive(digit + 1, remainingSum - digit, remainingSize - 1)
         }
     }
-    --NF
+    NF--
 }

--- a/exercises/practice/killer-sudoku-helper/.meta/example.awk
+++ b/exercises/practice/killer-sudoku-helper/.meta/example.awk
@@ -11,7 +11,7 @@ BEGIN {
     generate_recursive(1, cageSum, cageSize)
 }
 
-function generate_recursive(currentStartDigit, remainingSum, remainingSize,   maxPossibleFirstDigit,digit) {
+function generate_recursive(currentStartDigit, remainingSum, remainingSize,   maxPossibleFirstDigit, digit) {
     NF++
     if (remainingSize == 1) {
         if (currentStartDigit <= remainingSum && remainingSum <= MaxDigit && !(remainingSum in ExcludedDigits)) {
@@ -19,7 +19,7 @@ function generate_recursive(currentStartDigit, remainingSum, remainingSize,   ma
             print
         }
     } else {
-        maxPossibleFirstDigit =  MaxDigit - remainingSize + 1
+        maxPossibleFirstDigit = MaxDigit - remainingSize + 1
         for (digit = currentStartDigit; digit <= maxPossibleFirstDigit; ++digit) {
             if (digit in ExcludedDigits)
                 continue

--- a/exercises/practice/killer-sudoku-helper/.meta/example.awk
+++ b/exercises/practice/killer-sudoku-helper/.meta/example.awk
@@ -1,0 +1,29 @@
+BEGIN {
+    MaxDigit = 9
+}
+{
+    for (i = 3; i <= NF; ++i) {
+        ExcludedDigits[$i] = 1
+    }
+    NF = 0
+    generate_recursive(1, $1, $2)
+}
+
+function generate_recursive(currentStartDigit, remainingSum, remainingSize,   maxPossibleFirstDigit,digit) {
+    ++NF
+    if (remainingSize == 1) {
+        if (currentStartDigit <= remainingSum && remainingSum <= MaxDigit && !(remainingSum in ExcludedDigits)) {
+            $NF = remainingSum
+            print
+        }
+    } else {
+        maxPossibleFirstDigit =  MaxDigit - remainingSize + 1
+        for (digit = currentStartDigit; digit <= maxPossibleFirstDigit; ++digit) {
+            if (digit in ExcludedDigits)
+                continue
+            $NF = digit
+            generate_recursive(digit + 1, remainingSum - digit, remainingSize - 1)
+        }
+    }
+    --NF
+}

--- a/exercises/practice/killer-sudoku-helper/.meta/tests.toml
+++ b/exercises/practice/killer-sudoku-helper/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2aaa8f13-11b5-4054-b95c-a906e4d79fb6]
+description = "Trivial 1-digit cages -> 1"
+
+[4645da19-9fdd-4087-a910-a6ed66823563]
+description = "Trivial 1-digit cages -> 2"
+
+[07cfc704-f8aa-41b2-8f9a-cbefb674cb48]
+description = "Trivial 1-digit cages -> 3"
+
+[22b8b2ba-c4fd-40b3-b1bf-40aa5e7b5f24]
+description = "Trivial 1-digit cages -> 4"
+
+[b75d16e2-ff9b-464d-8578-71f73094cea7]
+description = "Trivial 1-digit cages -> 5"
+
+[bcbf5afc-4c89-4ff6-9357-07ab4d42788f]
+description = "Trivial 1-digit cages -> 6"
+
+[511b3bf8-186f-4e35-844f-c804d86f4a7a]
+description = "Trivial 1-digit cages -> 7"
+
+[bd09a60d-3aca-43bd-b6aa-6ccad01bedda]
+description = "Trivial 1-digit cages -> 8"
+
+[9b539f27-44ea-4ff8-bd3d-c7e136bee677]
+description = "Trivial 1-digit cages -> 9"
+
+[0a8b2078-b3a4-4dbd-be0d-b180f503d5c3]
+description = "Cage with sum 45 contains all digits 1:9"
+
+[2635d7c9-c716-4da1-84f1-c96e03900142]
+description = "Cage with only 1 possible combination"
+
+[a5bde743-e3a2-4a0c-8aac-e64fceea4228]
+description = "Cage with several combinations"
+
+[dfbf411c-737d-465a-a873-ca556360c274]
+description = "Cage with several combinations that is restricted"

--- a/exercises/practice/killer-sudoku-helper/bats-extra.bash
+++ b/exercises/practice/killer-sudoku-helper/bats-extra.bash
@@ -1,0 +1,637 @@
+# This is the source code for bats-support and bats-assert, concatenated
+# * https://github.com/bats-core/bats-support
+# * https://github.com/bats-core/bats-assert
+#
+# Comments have been removed to save space. See the git repos for full source code.
+
+############################################################
+#
+# bats-support - Supporting library for Bats test helpers
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+fail() {
+  (( $# == 0 )) && batslib_err || batslib_err "$@"
+  return 1
+}
+
+batslib_is_caller() {
+  local -i is_mode_direct=1
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -i|--indirect) is_mode_direct=0; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # Arguments.
+  local -r func="$1"
+
+  # Check call stack.
+  if (( is_mode_direct )); then
+    [[ $func == "${FUNCNAME[2]}" ]] && return 0
+  else
+    local -i depth
+    for (( depth=2; depth<${#FUNCNAME[@]}; ++depth )); do
+      [[ $func == "${FUNCNAME[$depth]}" ]] && return 0
+    done
+  fi
+
+  return 1
+}
+
+batslib_err() {
+  { if (( $# > 0 )); then
+      echo "$@"
+    else
+      cat -
+    fi
+  } >&2
+}
+
+batslib_count_lines() {
+  local -i n_lines=0
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    (( ++n_lines ))
+  done < <(printf '%s' "$1")
+  echo "$n_lines"
+}
+
+batslib_is_single_line() {
+  for string in "$@"; do
+    (( $(batslib_count_lines "$string") > 1 )) && return 1
+  done
+  return 0
+}
+
+batslib_get_max_single_line_key_width() {
+  local -i max_len=-1
+  while (( $# != 0 )); do
+    local -i key_len="${#1}"
+    batslib_is_single_line "$2" && (( key_len > max_len )) && max_len="$key_len"
+    shift 2
+  done
+  echo "$max_len"
+}
+
+batslib_print_kv_single() {
+  local -ir col_width="$1"; shift
+  while (( $# != 0 )); do
+    printf '%-*s : %s\n' "$col_width" "$1" "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_multi() {
+  while (( $# != 0 )); do
+    printf '%s (%d lines):\n' "$1" "$( batslib_count_lines "$2" )"
+    printf '%s\n' "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_single_or_multi() {
+  local -ir width="$1"; shift
+  local -a pairs=( "$@" )
+
+  local -a values=()
+  local -i i
+  for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+    values+=( "${pairs[$i]}" )
+  done
+
+  if batslib_is_single_line "${values[@]}"; then
+    batslib_print_kv_single "$width" "${pairs[@]}"
+  else
+    local -i i
+    for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+    done
+    batslib_print_kv_multi "${pairs[@]}"
+  fi
+}
+
+batslib_prefix() {
+  local -r prefix="${1:-  }"
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    printf '%s%s\n' "$prefix" "$line"
+  done
+}
+
+batslib_mark() {
+  local -r symbol="$1"; shift
+  # Sort line numbers.
+  set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
+
+  local line
+  local -i idx=0
+  while IFS='' read -r line || [[ -n $line ]]; do
+    if (( ${1:--1} == idx )); then
+      printf '%s\n' "${symbol}${line:${#symbol}}"
+      shift
+    else
+      printf '%s\n' "$line"
+    fi
+    (( ++idx ))
+  done
+}
+
+batslib_decorate() {
+  echo
+  echo "-- $1 --"
+  cat -
+  echo '--'
+  echo
+}
+
+############################################################
+
+assert() {
+  if ! "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion failed' \
+    | fail
+  fi
+}
+
+assert_equal() {
+  if [[ $1 != "$2" ]]; then
+    batslib_print_kv_single_or_multi 8 \
+    'expected' "$2" \
+    'actual'   "$1" \
+    | batslib_decorate 'values do not equal' \
+    | fail
+  fi
+}
+
+assert_failure() {
+  : "${output?}"
+  : "${status?}"
+
+  (( $# > 0 )) && local -r expected="$1"
+  if (( status == 0 )); then
+    batslib_print_kv_single_or_multi 6 'output' "$output" \
+    | batslib_decorate 'command succeeded, but it was expected to fail' \
+    | fail
+  elif (( $# > 0 )) && (( status != expected )); then
+    { local -ir width=8
+      batslib_print_kv_single "$width" \
+      'expected' "$expected" \
+      'actual'   "$status"
+      batslib_print_kv_single_or_multi "$width" \
+      'output' "$output"
+    } \
+    | batslib_decorate 'command failed as expected, but status differs' \
+    | fail
+  fi
+}
+
+assert_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: assert_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r expected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $expected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$expected'" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if ! [[ ${lines[$idx]} =~ $expected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$expected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression does not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} != *"$expected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$expected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line does not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} != "$expected" ]]; then
+        batslib_print_kv_single 8 \
+        'index'    "$idx" \
+        'expected' "$expected" \
+        'actual'   "${lines[$idx]}" \
+        | batslib_decorate 'line differs' \
+        | fail
+      fi
+    fi
+  else
+    # Contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} =~ $expected ]] && return 0
+      done
+      { local -ar single=( 'regexp' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line matches regular expression' \
+      | fail
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == *"$expected"* ]] && return 0
+      done
+      { local -ar single=( 'substring' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line contains substring' \
+      | fail
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == "$expected" ]] && return 0
+      done
+      { local -ar single=( 'line' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'output does not contain line' \
+      | fail
+    fi
+  fi
+}
+
+assert_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_nonempty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_nonempty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local expected
+  if (( use_stdin )); then
+    expected="$(cat -)"
+  else
+    expected="${1-}"
+  fi
+
+  # Matching.
+  if (( is_mode_nonempty )); then
+    if [ -z "$output" ]; then
+      echo 'expected non-empty output, but output was empty' \
+      | batslib_decorate 'no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      echo "Invalid extended regular expression: \`$expected'" \
+      | batslib_decorate 'ERROR: assert_output' \
+      | fail
+    elif ! [[ $output =~ $expected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$expected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression does not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output != *"$expected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$expected" \
+      'output'    "$output" \
+      | batslib_decorate 'output does not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output != "$expected" ]]; then
+      batslib_print_kv_single_or_multi 8 \
+      'expected' "$expected" \
+      'actual'   "$output" \
+      | batslib_decorate 'output differs' \
+      | fail
+    fi
+  fi
+}
+
+assert_success() {
+  : "${output?}"
+  : "${status?}"
+
+  if (( status != 0 )); then
+    { local -ir width=6
+      batslib_print_kv_single "$width" 'status' "$status"
+      batslib_print_kv_single_or_multi "$width" 'output' "$output"
+    } \
+    | batslib_decorate 'command failed' \
+    | fail
+  fi
+}
+
+refute() {
+  if "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion succeeded, but it was expected to fail' \
+    | fail
+  fi
+}
+
+refute_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: refute_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r unexpected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if [[ ${lines[$idx]} =~ $unexpected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$unexpected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression should not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$unexpected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line should not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} == "$unexpected" ]]; then
+        batslib_print_kv_single 5 \
+        'index' "$idx" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'line should differ' \
+        | fail
+      fi
+    fi
+  else
+    # Line contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} =~ $unexpected ]]; then
+          { local -ar single=( 'regexp' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should match the regular expression' \
+          | fail
+          return $?
+        fi
+      done
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+          { local -ar single=( 'substring' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should contain substring' \
+          | fail
+          return $?
+        fi
+      done
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$unexpected" ]]; then
+          { local -ar single=( 'line' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'line should not be in output' \
+          | fail
+          return $?
+        fi
+      done
+    fi
+  fi
+}
+
+refute_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_empty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_empty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local unexpected
+  if (( use_stdin )); then
+    unexpected="$(cat -)"
+  else
+    unexpected="${1-}"
+  fi
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_mode_empty )); then
+    if [ -n "$output" ]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output non-empty, but expected no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ $output =~ $unexpected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$unexpected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression should not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output == *"$unexpected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$unexpected" \
+      'output'    "$output" \
+      | batslib_decorate 'output should not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output == "$unexpected" ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output equals, but it was expected to differ' \
+      | fail
+    fi
+  fi
+}

--- a/exercises/practice/killer-sudoku-helper/killer-sudoku-helper.awk
+++ b/exercises/practice/killer-sudoku-helper/killer-sudoku-helper.awk
@@ -1,0 +1,4 @@
+BEGIN {
+    print "Implement this solution" > "/dev/stderr"
+    exit 1
+}

--- a/exercises/practice/killer-sudoku-helper/test-killer-sudoku-helper.bats
+++ b/exercises/practice/killer-sudoku-helper/test-killer-sudoku-helper.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# AWK script input format:
+# sum size [exclude_digit1 exclude_digit2 ...]
+# Example: 10 2 1 4
+# (This means a cage sum of 10, with 2 digits, excluding 1 and 4 from possible options)
+
+# Test case 1: Trivial 1-digit cages - 1
+@test "1" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "1 1"
+  assert_success
+  assert_output "1"
+}
+
+# Test case 2: Trivial 1-digit cages - 2
+@test "2" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "2 1"
+  assert_success
+  assert_output "2"
+}
+
+# Test case 3: Trivial 1-digit cages - 3
+@test "3" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "3 1"
+  assert_success
+  assert_output "3"
+}
+
+# Test case 4: Trivial 1-digit cages - 4
+@test "4" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "4 1"
+  assert_success
+  assert_output "4"
+}
+
+# Test case 5: Trivial 1-digit cages - 5
+@test "5" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "5 1"
+  assert_success
+  assert_output "5"
+}
+
+# Test case 6: Trivial 1-digit cages - 6
+@test "6" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "6 1"
+  assert_success
+  assert_output "6"
+}
+
+# Test case 7: Trivial 1-digit cages - 7
+@test "7" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "7 1"
+  assert_success
+  assert_output "7"
+}
+
+# Test case 8: Trivial 1-digit cages - 8
+@test "8" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "8 1"
+  assert_success
+  assert_output "8"
+}
+
+# Test case 9: Trivial 1-digit cages - 9
+@test "9" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "9 1"
+  assert_success
+  assert_output "9"
+}
+
+# Test case 10: Cage with sum 45 contains all digits 1:9
+@test "Cage with sum 45 contains all digits 1:9" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "45 9"
+  assert_success
+  assert_output "1 2 3 4 5 6 7 8 9"
+}
+
+# Test case 11: Cage with only 1 possible combination
+@test "Cage with only 1 possible combination" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "7 3"
+  assert_success
+  assert_output "1 2 4"
+}
+
+# Test case 12: Cage with several combinations
+@test "Cage with several combinations" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "10 2"
+  assert_success
+  assert_line -n 4 # Ensure there are 4 lines of output
+  assert_line --index 0 "1 9"
+  assert_line --index 1 "2 8"
+  assert_line --index 2 "3 7"
+  assert_line --index 3 "4 6"
+}
+
+# Test case 13: Cage with several combinations that is restricted
+@test "Cage with several combinations that is restricted" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f killer-sudoku-helper.awk <<< "10 2 1 4"
+  assert_success
+  assert_line -n 2 # Ensure there are 2 lines of output
+  assert_line --index 0 "2 8"
+  assert_line --index 1 "3 7"
+}


### PR DESCRIPTION
Add Killer Sudoku Helper exercise  

Introduce the new "Killer Sudoku Helper" exercise, comprising the problem description, example implementation (`example.awk`), test cases (`test-killer-sudoku-helper.bats`), and configuration updates. Includes dependencies on BATS support and assert libraries for testing.

Closes #310 