### PR TITLE
fix number of sentences in 3rd automated readability index test

### DIFF
--- a/exercises/practice/automated-readability-index/.meta/example.awk
+++ b/exercises/practice/automated-readability-index/.meta/example.awk
@@ -3,13 +3,14 @@
 BEGIN {
     CONVFMT = "%.0f"
     OFMT = "%.2f"
-    RS = @/[!?.]+[[:space:]]+/
+    RS = @/[!?.]+"?/
     split("5-6 6-7 7-8 8-9 9-10 10-11 11-12 12-13 13-14 14-15 15-16 16-17 17-18 18-22", Ages)
 
     print "The text is:"
 }
 NR < 4 {
     gsub(/[[:space:]]+/, " ")
+    gsub(/^[[:space:]]+/, "")
 
     if (length($0) > 50)
         print substr($0, 1, 50) "..."
@@ -21,7 +22,7 @@ NR == 4 {
 }
 NF {
     ++Sentences
-    ++Characters
+    Characters += length(RT)
     Words += NF
     for (i = 1; i <= NF; ++i) {
         Characters += length($i)

--- a/exercises/practice/automated-readability-index/test-automated-readability-index.bats
+++ b/exercises/practice/automated-readability-index/test-automated-readability-index.bats
@@ -96,8 +96,8 @@ teardown() {
     assert_line --partial --index 3 "If his mother says, \"Brush your teeth,\" Billy brus..."
     assert_line --index 4 "..."
     assert_line --index 5 "Words: 108"
-    assert_line --index 6 "Sentences: 13"
+    assert_line --index 6 "Sentences: 14"
     assert_line --index 7 "Characters: 442"
-    assert_line --index 8 "Score: 2.00"
+    assert_line --index 8 "Score: 1.70"
     assert_line --index 9 "This text should be understood by 6-7 year-olds."
 }


### PR DESCRIPTION
It seems pretty clear that there are 14 sentences.  The example implementation counted 13 because it requires whitespace after a period, but one of the sentences has a closing quotation mark after the period.

The simplest solution seems to be to include the closing quotation mark in the preceding sentence (and word).  Therefore we need to count its length as part of RT and adjust how whitespace is handled a bit.

The resulting score necessarily goes down because the number of sentences goes up.