### PR TITLE
feat: Add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,81 @@
+# .editorconfig for the Exercism AWK track repository
+# https://spec.editorconfig.org/
+
+# Top-most EditorConfig file
+# A best practice to prevent settings from parent directories from interfering.
+root = true
+
+# Universal settings for all files. These are the baseline rules.
+[*]
+
+# Sets the character set to UTF-8, the universal standard for text files.
+charset = utf-8
+
+# Enforces Unix-style line endings (LF)
+end_of_line = lf
+
+# Ensures files are POSIX-compliant and prevents issues with some command-line tools.
+insert_final_newline = true
+
+# Keeps the codebase clean and avoids noise in diffs.
+trim_trailing_whitespace = true
+
+# Specifies the language for the IDE's spell checker.
+spelling_language = en-US
+
+
+# Settings for files we edit, overriding universal settings where needed.
+
+# AWK solution/example files use 4-space indentation.
+# max_line_length is unset here because some files contain very long
+# lines with embedded data, making a fixed line length impractical.
+[*.awk]
+indent_style = space
+indent_size = 4
+max_line_length = unset
+
+# BATS test files use 4-space indentation.
+# max_line_length is unset here because some test files contain very long
+# lines with embedded data, making a fixed line length impractical.
+[*.bats]
+indent_style = space
+indent_size = 4
+max_line_length = unset
+
+# For Markdown files, specific settings are needed to preserve formatting.
+[*.md]
+# Disable trimming trailing whitespace, as two spaces can create a hard line break.
+trim_trailing_whitespace = false
+max_line_length = unset
+
+# Override for common data and config formats to use 2-space indentation
+# and disable line length checks, as they often contain long strings.
+[*.{json,yml,yaml,xml}]
+indent_size = 2
+indent_style = space
+max_line_length = unset
+
+# This is an auto-generated file.
+[tests.toml]
+indent_size = unset
+indent_style = unset
+
+# Shell scripts in the bin directory are hand-written, so a line length
+# limit improves readability.
+[bin/*]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+# This file is a copy of the
+# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
+[bin/fetch-configlet*]
+indent_size = unset
+indent_style = unset
+
+# The formatting of a LICENSE file is often fixed and should not be altered.
+# Unsetting these rules prevents the editor from modifying it.
+[LICENSE]
+indent_size = unset
+indent_style = unset
+


### PR DESCRIPTION
Hi team,

This pull request introduces a `.editorconfig` file to the root of our repository.

## Motivation

I'm proposing this change to address a common source of friction I've experienced, where commits fail in CI simply due to a missing final newline in a file. By defining a core set of formatting rules that are automatically applied by most code editors, we can eliminate this entire class of errors and make the contribution process smoother for everyone.

As I wrote about recently on [my blog](https://jc.id.lv/posts/introduction-to-editorconfig/), this single file can help unify formatting across our team's diverse development environments.

## Benefits of `.editorconfig`

- **Automated Consistency:** Automatically enforces basic rules like line endings, character sets, and the presence of a final newline.
    
- **Reduced CI Noise:** Prevents trivial CI failures, allowing us to focus on the substance of our changes.
    
- **Editor Agnostic:** It's a single, standard configuration file supported by a vast range of editors and IDEs (including JetBrains IDEs, VS Code with a popular extension, Vim, Emacs, and more). This avoids the need for editor-specific settings files.
    
- **Opt-in Enhancement:** For contributors whose editors support it, the experience is improved. For those who don't, nothing is enforced, and our existing CI linters will still act as the final backstop. It's a helpful enhancement, not a strict requirement.
    

## About This Configuration

I've created this configuration file based on a detailed analysis of our repository's structure. Key decisions include:

- **Universal Standards:** Enforces `UTF-8`, `LF` line endings, and the crucial `insert_final_newline`.
    
- **Language-Specific Indentation:** Sets appropriate indentation for `.awk`, `.bats`, `.json`, and `.yml` files.
    
- **Flexible Line Length:** `max_line_length` is intentionally `unset` for `.awk` and `.bats` files, as our analysis showed that many example and test files contain long lines with embedded data that shouldn't be wrapped.
    
- **Respect for Generated Files:** Rules are explicitly `unset` for files we don't edit, like `LICENSE` and `fetch-configlet`, to prevent unintended changes.
    
I'm very open to discussion on this file. Please feel free to review, comment, and suggest any changes. Let's make this configuration work perfectly for our track!

Looking forward to your feedback.