### PR TITLE
Remove GNU grep requirement so validation can run on macos.

### DIFF
--- a/bin/validate_exercises
+++ b/bin/validate_exercises
@@ -9,12 +9,14 @@ set -o nounset
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 declare -A exercises
-while read -r exercise; do exercises["$exercise"]=1; done < <(
+while read -r exercise; do
+    exercises["$exercise"]=1
+done < <(
     jq -r '
-        .exercises  as $exs 
-        | ["concept","practice"][] 
-        | . as $type 
-        | $exs[$type][] 
+        .exercises  as $exs
+        | ["concept","practice"][]
+        | . as $type
+        | $exs[$type][]
         | "exercises/\($type)/\(.slug)"
     ' config.json
 )
@@ -23,25 +25,34 @@ warnings=0
 errors=0
 shopt -s nullglob
 
+warnings=()
+errors=()
 for exercise in exercises/{concept,practice}/*; do
     if [[ -v exercises[$exercise] ]]; then
         unset "exercises[$exercise]"
     else
-        echo "*** WARNING: $exercise does not appear in config.json!" >&2
-        ((++warnings))
+        warnings+=("$exercise does not appear in config.json!")
     fi
 
-    bin/validate_one_exercise "$exercise" || ((++errors))
+    bin/validate_one_exercise "$exercise" || errors+=("$exercise")
     echo
 done
 
 for exercise in "${!exercises[@]}"; do
-    echo "*** WARNING: $exercise is in config.json but does not exist in the repo!" >&2
-    ((++warnings))
+    warnings+=("$exercise is in config.json but does not exist in the repo!")
 done
 
 echo "Testing finished"
-if (( warnings + errors > 0 )); then
-    printf "\t%d warnings\n\t%d errors\n" "$warnings" "$errors"
-    exit 1
+
+status=0
+if (( ${#warnings[@]} > 0 )); then
+    echo 'Warnings:' >&2
+    printf '\t%s\n' "${warnings[@]}" >&2
+    ((++status))
 fi
+if (( ${#errors[@]} > 0 )); then
+    echo 'Errors:' >&2
+    printf '\t%s\n' "${errors[@]}" >&2
+    ((++status))
+fi
+exit "$status"

--- a/bin/validate_one_exercise
+++ b/bin/validate_one_exercise
@@ -11,7 +11,6 @@ die() { echo "$*" >&2; exit 1; }
 # check prerequisites
 command -v jq    >/dev/null      || die "This script requires jq: please install it."
 command -v bats  >/dev/null      || die "This script requires bats-core: please install it."
-grep -P 1 <<< 1  >/dev/null 2>&1 || die "This script requires GNU grep: please install it."
 
 cd "$1" || die "Cannot cd to $1"
 
@@ -36,10 +35,8 @@ readarray -t editor_files < <(jq -r '.files.editor[]?' "$config")
 # hello-world has no skips
 # neither do concept exercises
 if [[ ${exercise} != "hello-world" ]] && [[ $PWD != */exercises/concept/* ]]; then
-    # a PCRE: the `\Q...\E` defines a literal segment
-    # shellcheck disable=SC2016 
-    skip_re='^\s*#+\s*\Q[[ $BATS_RUN_SKIPPED == "true" ]] || skip\E$'
-    num_skip_comments=$(grep -cP "${skip_re}" "${tests}") || :
+    # shellcheck disable=SC2016
+    num_skip_comments=$(grep -cE '^ *#+ *\[\[ \$BATS_RUN_SKIPPED == "true" \]\] \|\| skip' "${tests}")
     (( num_skip_comments == 1 )) || die "There should be exactly one commented skip directive in ${tests}"
 fi
 


### PR DESCRIPTION
General improvements to readability and output.

* validate_one_exercise is the main change to stop using `grep -P`
* validate_exercises changes to make the summary output more informative. Some whitespace changes in here.