### PR TITLE
Remove unnecessary parentheses around print statements

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/example.awk
+++ b/exercises/practice/atbash-cipher/.meta/example.awk
@@ -28,5 +28,5 @@ BEGIN {
         }
         out = out substr($0, i, 5)
     }
-    print(out)
+    print out
 }

--- a/exercises/practice/nth-prime/.meta/example.awk
+++ b/exercises/practice/nth-prime/.meta/example.awk
@@ -3,11 +3,11 @@
 
 BEGIN {
     if (n < 1) {
-        print("invalid input")
+        print "invalid input"
         exit(1)
     }
     if (n == 1) {
-        print(2)
+        print 2
         exit(0)
     }
 

--- a/exercises/practice/prime-factors/.meta/example.awk
+++ b/exercises/practice/prime-factors/.meta/example.awk
@@ -12,5 +12,5 @@
             candidate++
         }
     }
-    print(out)
+    print out
 }

--- a/exercises/practice/protein-translation/.meta/example.awk
+++ b/exercises/practice/protein-translation/.meta/example.awk
@@ -24,7 +24,7 @@ BEGIN {
     out = ""
     for (i = 1; i <= NF; i++) {
         if (! translation[$i]) {
-            print("Invalid codon")
+            print "Invalid codon"
             exit(1)
         }
         if (translation[$i] == "STOP")
@@ -34,9 +34,9 @@ BEGIN {
         out = out translation[$i]
     }
     if (length % 3 && translation[$i] != "STOP") {
-        print("Invalid codon")
+        print "Invalid codon"
         exit(1)
     }
 
-    print(out)
+    print out 
 }

--- a/exercises/practice/resistor-color-duo/.meta/example.awk
+++ b/exercises/practice/resistor-color-duo/.meta/example.awk
@@ -6,11 +6,11 @@ function value(color) {
     for (i = 1; i <= length(colors); i++)
         if (colors[i] == color)
             return i - 1
-    print("invalid color")
+    print "invalid color"
     exit(1)
 }
 
 {
-    print(value($1) * 10 +  value($2))
+    print value($1) * 10 +  value($2)
 }
 

--- a/exercises/practice/resistor-color-trio/.meta/example.awk
+++ b/exercises/practice/resistor-color-trio/.meta/example.awk
@@ -7,7 +7,7 @@ function value(color) {
     for (i = 1; i <= length(colors); i++)
         if (colors[i] == color)
             return i - 1
-    print("invalid color")
+    print "invalid color"
     exit(1)
 }
 
@@ -19,6 +19,6 @@ function value(color) {
         shifted++
         ohms /= 1000
     }
-    print(ohms " " units[shifted] "ohms")
+    print ohms " " units[shifted] "ohms"
 }
 

--- a/exercises/practice/rna-transcription/.meta/example.awk
+++ b/exercises/practice/rna-transcription/.meta/example.awk
@@ -13,9 +13,9 @@ BEGIN {
         if ($i in translation) {
             out = out translation[$i]
         } else {
-            print("Invalid nucleotide detected.")
+            print "Invalid nucleotide detected." 
             exit(1)
         }
     }
-    print(out)
+    print out 
 }

--- a/exercises/practice/series/.meta/example.awk
+++ b/exercises/practice/series/.meta/example.awk
@@ -18,5 +18,5 @@ len > NF { print "slice length cannot be greater than series length"; exit(1) }
         for (i = 0; i < len; i++)
             out = out $(start + i)
     }
-    print(out)
+    print out
 }

--- a/exercises/practice/space-age/.meta/example.awk
+++ b/exercises/practice/space-age/.meta/example.awk
@@ -15,7 +15,7 @@ BEGIN {
     if (earth_ratio[$1]) {
         printf("%.2f\n", ($2 / seconds_per_earth_year) / earth_ratio[$1])
     } else {
-        print($1 " is not a planet")
+        print $1 " is not a planet"
         exit(1)
     }
 }

--- a/exercises/practice/triangle/.meta/example.awk
+++ b/exercises/practice/triangle/.meta/example.awk
@@ -5,14 +5,14 @@
     # A triangle must have non-zero size.
     perimeter = $1 + $2 + $3
     if (perimeter == 0) {
-        print("false")
+        print "false"
         exit(0)
     }
 
     # Any one side cannot be larger than both other sides.
     for (i = 1; i <= 3; i++) {
         if (2 * $i > perimeter) {
-            print("false")
+            print "false"
             exit(0)
         }
     }
@@ -29,5 +29,5 @@
         break
     }
 
-    print(result ? "true" : "false")
+    print result ? "true" : "false"
 }


### PR DESCRIPTION
Fixes #430

  Removed unnecessary parentheses around `print` statements in the
  following example solutions, per the issue's guidance (parens are
  only needed when disambiguating a `>` redirection, which none of
  these cases involve):

  - atbash-cipher
  - series
  - rna-transcription
  - protein-translation
  - prime-factors
  - space-age
  - nth-prime
  - resistor-color-duo
  - resistor-color-trio
  - triangle