### PR TITLE
Print error messages to stderr in example solutions (#431)

### DIFF
--- a/exercises/practice/house/.meta/example.awk
+++ b/exercises/practice/house/.meta/example.awk
@@ -5,7 +5,7 @@
 
 BEGIN {
     if (start < 1 || end > 12 || start > end) {
-        print "Error: invalid range. Start must be >= 1, end <= 12, and start <= end."
+        print "Error: invalid range. Start must be >= 1, end <= 12, and start <= end." > "/dev/stderr"
         exit 1
     }
 

--- a/exercises/practice/nth-prime/.meta/example.awk
+++ b/exercises/practice/nth-prime/.meta/example.awk
@@ -3,7 +3,7 @@
 
 BEGIN {
     if (n < 1) {
-        print("invalid input")
+        print "invalid input" > "/dev/stderr"
         exit(1)
     }
     if (n == 1) {

--- a/exercises/practice/phone-number/.meta/example.awk
+++ b/exercises/practice/phone-number/.meta/example.awk
@@ -1,5 +1,5 @@
 function die(msg) {
-    print msg
+    print msg > "/dev/stderr"
     exit 1
 }
 

--- a/exercises/practice/protein-translation/.meta/example.awk
+++ b/exercises/practice/protein-translation/.meta/example.awk
@@ -24,7 +24,7 @@ BEGIN {
     out = ""
     for (i = 1; i <= NF; i++) {
         if (! translation[$i]) {
-            print("Invalid codon")
+            print "Invalid codon" > "/dev/stderr"
             exit(1)
         }
         if (translation[$i] == "STOP")
@@ -34,7 +34,7 @@ BEGIN {
         out = out translation[$i]
     }
     if (length % 3 && translation[$i] != "STOP") {
-        print("Invalid codon")
+        print "Invalid codon" > "/dev/stderr"
         exit(1)
     }
 

--- a/exercises/practice/queen-attack/.meta/example.awk
+++ b/exercises/practice/queen-attack/.meta/example.awk
@@ -5,11 +5,11 @@ function abs(val) {
 {
     for (i = 1; i <= NF; i++)
         if ($i < 0 || $i > 7) {
-            print "invalid position: row or column is not on the board"
+            print "invalid position: row or column is not on the board" > "/dev/stderr"
             exit 1
         }
     if ($1 == $3 && $2 == $4) {
-        print "invalid position: pieces are on the same tile"
+        print "invalid position: pieces are on the same tile" > "/dev/stderr"
         exit 1
     }
     # Same row or same column.

--- a/exercises/practice/resistor-color-duo/.meta/example.awk
+++ b/exercises/practice/resistor-color-duo/.meta/example.awk
@@ -6,7 +6,7 @@ function value(color) {
     for (i = 1; i <= length(colors); i++)
         if (colors[i] == color)
             return i - 1
-    print("invalid color")
+    print "invalid color" > "/dev/stderr"
     exit(1)
 }
 

--- a/exercises/practice/resistor-color-trio/.meta/example.awk
+++ b/exercises/practice/resistor-color-trio/.meta/example.awk
@@ -7,7 +7,7 @@ function value(color) {
     for (i = 1; i <= length(colors); i++)
         if (colors[i] == color)
             return i - 1
-    print("invalid color")
+    print "invalid color" > "/dev/stderr"
     exit(1)
 }
 

--- a/exercises/practice/rna-transcription/.meta/example.awk
+++ b/exercises/practice/rna-transcription/.meta/example.awk
@@ -13,7 +13,7 @@ BEGIN {
         if ($i in translation) {
             out = out translation[$i]
         } else {
-            print("Invalid nucleotide detected.")
+            print "Invalid nucleotide detected." > "/dev/stderr"
             exit(1)
         }
     }

--- a/exercises/practice/series/.meta/example.awk
+++ b/exercises/practice/series/.meta/example.awk
@@ -5,10 +5,10 @@ BEGIN {
     FS = ""
 }
 
-!NF      { print "series cannot be empty"; exit(1) }
-len == 0 { print "slice length cannot be zero"; exit(1) }
-len < 0  { print "slice length cannot be negative"; exit(1) }
-len > NF { print "slice length cannot be greater than series length"; exit(1) }
+!NF      { print "series cannot be empty" > "/dev/stderr"; exit(1) }
+len == 0 { print "slice length cannot be zero" > "/dev/stderr"; exit(1) }
+len < 0  { print "slice length cannot be negative" > "/dev/stderr"; exit(1) }
+len > NF { print "slice length cannot be greater than series length" > "/dev/stderr"; exit(1) }
 
 {
     out = ""

--- a/exercises/practice/space-age/.meta/example.awk
+++ b/exercises/practice/space-age/.meta/example.awk
@@ -15,7 +15,7 @@ BEGIN {
     if (earth_ratio[$1]) {
         printf("%.2f\n", ($2 / seconds_per_earth_year) / earth_ratio[$1])
     } else {
-        print($1 " is not a planet")
+        print $1 " is not a planet" > "/dev/stderr"
         exit(1)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/exercism/awk/issues/431 [Error messages should be printed to stderr]
