### PR TITLE
Standardize on 'exit N' style in example solutions

### DIFF
--- a/exercises/practice/nth-prime/.meta/example.awk
+++ b/exercises/practice/nth-prime/.meta/example.awk
@@ -4,11 +4,11 @@
 BEGIN {
     if (n < 1) {
         print "invalid input" > "/dev/stderr"
-        exit(1)
+        exit 1
     }
     if (n == 1) {
         print 2
-        exit(0)
+        exit 0
     }
 
     primes[1] = 2

--- a/exercises/practice/protein-translation/.meta/example.awk
+++ b/exercises/practice/protein-translation/.meta/example.awk
@@ -25,7 +25,7 @@ BEGIN {
     for (i = 1; i <= NF; i++) {
         if (! translation[$i]) {
             print "Invalid codon" > "/dev/stderr"
-            exit(1)
+            exit 1
         }
         if (translation[$i] == "STOP")
             break
@@ -35,7 +35,7 @@ BEGIN {
     }
     if (length % 3 && translation[$i] != "STOP") {
         print "Invalid codon" > "/dev/stderr"
-        exit(1)
+        exit 1
     }
 
     print out 

--- a/exercises/practice/resistor-color-duo/.meta/example.awk
+++ b/exercises/practice/resistor-color-duo/.meta/example.awk
@@ -7,7 +7,7 @@ function value(color) {
         if (colors[i] == color)
             return i - 1
     print "invalid color" > "/dev/stderr"
-    exit(1)
+    exit 1
 }
 
 {

--- a/exercises/practice/resistor-color-trio/.meta/example.awk
+++ b/exercises/practice/resistor-color-trio/.meta/example.awk
@@ -8,7 +8,7 @@ function value(color) {
         if (colors[i] == color)
             return i - 1
     print "invalid color" > "/dev/stderr"
-    exit(1)
+    exit 1
 }
 
 {

--- a/exercises/practice/rna-transcription/.meta/example.awk
+++ b/exercises/practice/rna-transcription/.meta/example.awk
@@ -14,7 +14,7 @@ BEGIN {
             out = out translation[$i]
         } else {
             print "Invalid nucleotide detected." > "/dev/stderr"
-            exit(1)
+            exit 1
         }
     }
     print out 

--- a/exercises/practice/series/.meta/example.awk
+++ b/exercises/practice/series/.meta/example.awk
@@ -5,10 +5,10 @@ BEGIN {
     FS = ""
 }
 
-!NF      { print "series cannot be empty" > "/dev/stderr"; exit(1) }
-len == 0 { print "slice length cannot be zero" > "/dev/stderr"; exit(1) }
-len < 0  { print "slice length cannot be negative" > "/dev/stderr"; exit(1) }
-len > NF { print "slice length cannot be greater than series length" > "/dev/stderr"; exit(1) }
+!NF      { print "series cannot be empty" > "/dev/stderr"; exit 1 }
+len == 0 { print "slice length cannot be zero" > "/dev/stderr"; exit 1 }
+len < 0  { print "slice length cannot be negative" > "/dev/stderr"; exit 1 }
+len > NF { print "slice length cannot be greater than series length" > "/dev/stderr"; exit 1 }
 
 {
     out = ""

--- a/exercises/practice/space-age/.meta/example.awk
+++ b/exercises/practice/space-age/.meta/example.awk
@@ -16,6 +16,6 @@ BEGIN {
         printf("%.2f\n", ($2 / seconds_per_earth_year) / earth_ratio[$1])
     } else {
         print $1 " is not a planet" > "/dev/stderr"
-        exit(1)
+        exit 1
     }
 }

--- a/exercises/practice/tournament/.meta/example.awk
+++ b/exercises/practice/tournament/.meta/example.awk
@@ -54,7 +54,7 @@ length {
         draw($2)
         break
     default:
-        exit(1)
+        exit 1
     }
 }
 

--- a/exercises/practice/triangle/.meta/example.awk
+++ b/exercises/practice/triangle/.meta/example.awk
@@ -6,14 +6,14 @@
     perimeter = $1 + $2 + $3
     if (perimeter == 0) {
         print "false"
-        exit(0)
+        exit 0
     }
 
     # Any one side cannot be larger than both other sides.
     for (i = 1; i <= 3; i++) {
         if (2 * $i > perimeter) {
             print "false"
-            exit(0)
+            exit 0
         }
     }
 


### PR DESCRIPTION
Fixes #441
Files edited from exit(N) to exit N are:

exercises/practice/nth-prime/.meta/example.awk
exercises/practice/protein-translation/.meta/example.awk
exercises/practice/resistor-color-duo/.meta/example.awk
exercises/practice/resistor-color-trio/.meta/example.awk
exercises/practice/rna-transcription/.meta/example.awk
exercises/practice/series/.meta/example.awk
exercises/practice/space-age/.meta/example.awk
exercises/practice/tournament/.meta/example.awk
exercises/practice/triangle/.meta/example.awk