### PR TITLE
Remove the index from the test case loop; simplify the cases object

### DIFF
--- a/bin/generate_tests
+++ b/bin/generate_tests
@@ -119,7 +119,7 @@ def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
         """
     ).strip()
     data = {
-        "cases": list(enumerate(cases)),
+        "cases": cases,
         "header": header,
         "solution": json.loads((exercise / ".meta/config.json").read_text())["files"]["solution"][0]
     }

--- a/exercises/practice/acronym/.meta/template.j2
+++ b/exercises/practice/acronym/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["phrase"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/affine-cipher/.meta/template.j2
+++ b/exercises/practice/affine-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ [case["property"], case["input"]["key"]["a"], case["input"]["key"]["b"], case["input"]["phrase"]] | join("|") }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/all-your-base/.meta/template.j2
+++ b/exercises/practice/all-your-base/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v ibase={{ case["input"]["inputBase"] }} -v obase={{ case["input"]["outputBase"] }} <<< "{{ case["input"]["digits"] | join(" ") }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/allergies/.meta/template.j2
+++ b/exercises/practice/allergies/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "allergicTo" %}
     run gawk -f {{ solution }} <<< '{{ [case["input"]["score"], case["property"] | camel_to_snake, case["input"]["item"]] | join(",") }}'
     assert_success

--- a/exercises/practice/alphametics/.meta/template.j2
+++ b/exercises/practice/alphametics/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case.description }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run awk -f alphametics.awk <<< "{{ case.input.puzzle }}"
   assert_success
   {% if case.expected %}

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v key={{ case["input"]["subject"] }} <<WORD_LIST
 {{ case["input"]["candidates"] | join("\n") }}
 WORD_LIST

--- a/exercises/practice/armstrong-numbers/.meta/template.j2
+++ b/exercises/practice/armstrong-numbers/.meta/template.j2
@@ -3,9 +3,9 @@
 # The two large tests require the -M option to handle big numbers.
 # Refer to the instructions of the Grains exercise:
 #   https://exercism.org/tracks/awk/exercises/grains
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   {%- set flags="" %}
   {%- if case["input"]["number"] > 10000000 %}
     {%- set flags="-M " %}

--- a/exercises/practice/atbash-cipher/.meta/template.j2
+++ b/exercises/practice/atbash-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} -v direction={{ case["property"] }} <<< "{{ case["input"]["phrase"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v value={{ case["input"]["value"] }} <<< "{{ case["input"]["array"] | join(",") }}"
 {%- if case["expect_error"] %}
     assert_success

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< ${{ case["input"]["heyBob"] | repr}}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/book-store/.meta/template.j2
+++ b/exercises/practice/book-store/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<END_INPUT
 {%- if case["input"]["basket"] %}
 {{ case["input"]["basket"] | join("\n") }}

--- a/exercises/practice/bottle-song/.meta/template.j2
+++ b/exercises/practice/bottle-song/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v startBottles={{ case["input"]["startBottles"] }} -v takeDown={{ case["input"]["takeDown"] }}
 
     expected="{{ case["expected"] | join("\n") }}"

--- a/exercises/practice/bowling/.meta/template.j2
+++ b/exercises/practice/bowling/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     {%- set rolls = case["input"]["previousRolls"] %}
     {%- if case["property"] == "roll" %}
         {%- set rolls = rolls + [case["input"]["roll"]] %}

--- a/exercises/practice/change/.meta/template.j2
+++ b/exercises/practice/change/.meta/template.j2
@@ -6,9 +6,9 @@
 #
 # The output is expected to be a space separated list
 # of coins, sorted in ascending order
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<END_INPUT
 {{ case["input"]["coins"] | join(" ") }}
 {{ case["input"]["target"] }}

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -8,9 +8,9 @@
 # subtract hh mm delta
 # equal hh mm hh mm
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   {%- if case["property"] == "equal" %}
     {%- set args = [
           case["property"],

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["number"] }}"
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/crypto-square/.meta/template.j2
+++ b/exercises/practice/crypto-square/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["plaintext"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/darts/.meta/template.j2
+++ b/exercises/practice/darts/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< '{{ case["input"]["x"] }} {{ case["input"]["y"] }}'
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/diamond/.meta/template.j2
+++ b/exercises/practice/diamond/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["letter"] }}
     assert_success
     {%- for line in case["expected"] %}

--- a/exercises/practice/difference-of-squares/.meta/template.j2
+++ b/exercises/practice/difference-of-squares/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["property"] | camel_to_snake | replace("difference_of_squares", "difference") }},{{ case["input"]["number"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/eliuds-eggs/.meta/template.j2
+++ b/exercises/practice/eliuds-eggs/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["number"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/flower-field/.meta/template.j2
+++ b/exercises/practice/flower-field/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} << 'END_INPUT'
 {%- if case["input"]["garden"] %}
 {{ case["input"]["garden"] | join("\n") | replace(" ", ".") }}

--- a/exercises/practice/food-chain/.meta/template.j2
+++ b/exercises/practice/food-chain/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat << END_EXPECTED
 {{ case["expected"] | join("\n") }}
 END_EXPECTED

--- a/exercises/practice/forth/.meta/template.j2
+++ b/exercises/practice/forth/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<END
 {{ case["input"]["instructions"] | join("\n")}}
 END

--- a/exercises/practice/forth/test-forth.bats
+++ b/exercises/practice/forth/test-forth.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 load bats-extra
 
-# generated on 2026-06-30T17:59:19+00:00
+# generated on 2026-08-13T17:20:33+00:00
 
 @test "parsing and numbers: numbers just get pushed onto the stack" {
     # [[ $BATS_RUN_SKIPPED == "true" ]] || skip
@@ -503,7 +503,7 @@ END
 }
 
 
-@test macro_empty_definition {
+@test "new word with empty definition" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f forth.awk <<END
 : foo ;
@@ -512,7 +512,7 @@ END
     assert_output --partial "empty macro definition"
 }
 
-@test macro_missing_semicolon {
+@test "new word definition missing the required semicolon" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f forth.awk <<END
 : foo 1
@@ -524,7 +524,7 @@ END
 
 # each file gets it's own forth evaluator:
 # a stack and macros, and prints the stack at the end of the file
-@test each_file_gets_its_own_forth {
+@test "each input file has its own evaluator" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     echo ': + - ;' >  first.txt
     echo '1 1 +'   >> first.txt

--- a/exercises/practice/gigasecond/.meta/template.j2
+++ b/exercises/practice/gigasecond/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
   run gawk -f {{ solution }} <<< '{{ case["input"]["moment"] }}'
   assert_success

--- a/exercises/practice/grade-school/.meta/template.j2
+++ b/exercises/practice/grade-school/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "roster" %}
     run gawk -f {{ solution }} -v action={{ case["property"] }} << END_INPUT
 {%- else %}

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "total" %}
   run gawk -M -f {{ solution }} <<< total
 {%- else %}

--- a/exercises/practice/hamming/.meta/template.j2
+++ b/exercises/practice/hamming/.meta/template.j2
@@ -8,9 +8,9 @@ populate_test_file() {
 teardown() {
     rm -f input.txt
 }
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   populate_test_file '{{ case["input"]["strand1"] }}' '{{ case["input"]["strand2"] }}'
   run gawk -f {{ solution }} input.txt
 {%- if case["expect_error"] %}

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,5 +1,5 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
   run gawk -f {{ solution }}
 

--- a/exercises/practice/house/.meta/template.j2
+++ b/exercises/practice/house/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END
 {{ case["expected"] | join("\n") }}
 END

--- a/exercises/practice/isbn-verifier/.meta/template.j2
+++ b/exercises/practice/isbn-verifier/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["isbn"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/isogram/.meta/template.j2
+++ b/exercises/practice/isogram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["phrase"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/killer-sudoku-helper/.meta/template.j2
+++ b/exercises/practice/killer-sudoku-helper/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   expected=$(cat << END
 {{ case["expected"] | map("join", " ") | join("\n") }}
 END

--- a/exercises/practice/kindergarten-garden/.meta/template.j2
+++ b/exercises/practice/kindergarten-garden/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v name="{{ case["input"]["student"] }}" << END_GARDEN
 {{ case["input"]["diagram"] }}
 END_GARDEN

--- a/exercises/practice/knapsack/.meta/template.j2
+++ b/exercises/practice/knapsack/.meta/template.j2
@@ -5,9 +5,9 @@
 # weight:wt value:val
 # ...
 # END_INPUT
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} << END_INPUT
 limit:{{ case["input"]["maximumWeight"] }}
 {%- for item in case["input"]["items"] %}

--- a/exercises/practice/largest-series-product/.meta/template.j2
+++ b/exercises/practice/largest-series-product/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["digits"] }},{{ case["input"]["span"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/leap/.meta/template.j2
+++ b/exercises/practice/leap/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["year"] }}"
 
   assert_success

--- a/exercises/practice/line-up/.meta/template.j2
+++ b/exercises/practice/line-up/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["name"] }} {{ case["input"]["number"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/luhn/.meta/template.j2
+++ b/exercises/practice/luhn/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["value"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/matching-brackets/.meta/template.j2
+++ b/exercises/practice/matching-brackets/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< '{{ case["input"]["value"] }}'
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/matrix/.meta/template.j2
+++ b/exercises/practice/matrix/.meta/template.j2
@@ -2,9 +2,9 @@
 teardown() {
     rm input.txt
 }
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     printf "%s\n" ${{ case["input"]["string"] | repr }} > input.txt
 
     run gawk '

--- a/exercises/practice/meetup/.meta/template.j2
+++ b/exercises/practice/meetup/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{
         [
             case["input"]["year"],

--- a/exercises/practice/minesweeper/.meta/template.j2
+++ b/exercises/practice/minesweeper/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} << 'END_INPUT'
 {%- if case["input"]["minefield"] %}
 {{ case["input"]["minefield"] | join("\n") | replace(" ", ".") }}

--- a/exercises/practice/nth-prime/.meta/template.j2
+++ b/exercises/practice/nth-prime/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v n={{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/ocr-numbers/.meta/template.j2
+++ b/exercises/practice/ocr-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} << INPUT
 {{ case["input"]["rows"] | join("\n") }}
 INPUT

--- a/exercises/practice/pangram/.meta/template.j2
+++ b/exercises/practice/pangram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< '{{ case["input"]["sentence"] }}'
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/pascals-triangle/.meta/template.j2
+++ b/exercises/practice/pascals-triangle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$( cat << END
 {%- if case["expected"] %}
 {{ case["expected"] | map("join", " ") | join("\n") }}

--- a/exercises/practice/phone-number/.meta/template.j2
+++ b/exercises/practice/phone-number/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["phrase"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/pig-latin/.meta/template.j2
+++ b/exercises/practice/pig-latin/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["phrase"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/poker/.meta/template.j2
+++ b/exercises/practice/poker/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END_EXPECT
 {{ case["expected"] | join("\n") }}
 END_EXPECT

--- a/exercises/practice/prime-factors/.meta/template.j2
+++ b/exercises/practice/prime-factors/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["value"] }}
     assert_success
     assert_output "{{ case["expected"] | join(" ") }}"

--- a/exercises/practice/prism/.meta/template.j2
+++ b/exercises/practice/prism/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<EOF
 {{ [case["input"]["start"]["x"], case["input"]["start"]["y"], case["input"]["start"]["angle"]] | join(" ") }}
 {%- for prism in (case["input"]["prisms"] | sort(attribute="id")) %}

--- a/exercises/practice/protein-translation/.meta/template.j2
+++ b/exercises/practice/protein-translation/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["strand"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/proverb/.meta/template.j2
+++ b/exercises/practice/proverb/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$( cat <<EOF
 {%- if case["expected"] %}
 {{ case["expected"] | join("\n") }}

--- a/exercises/practice/pythagorean-triplet/.meta/template.j2
+++ b/exercises/practice/pythagorean-triplet/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<EOF
 {{ case["expected"] | map("join", ",") | join("\n") }}
 EOF

--- a/exercises/practice/raindrops/.meta/template.j2
+++ b/exercises/practice/raindrops/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} -v num={{ case["input"]["number"] }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rectangles/.meta/template.j2
+++ b/exercises/practice/rectangles/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<INPUT
 {%- if case["input"]["strings"] %}
 {{ case["input"]["strings"] | join("\n") }}

--- a/exercises/practice/resistor-color-duo/.meta/template.j2
+++ b/exercises/practice/resistor-color-duo/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["colors"] | join(" ") }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/resistor-color-trio/.meta/template.j2
+++ b/exercises/practice/resistor-color-trio/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["colors"] | join(" ") }}"
     assert_success
     assert_output "{{ case["expected"]["value"] }} {{ case["expected"]["unit"] }}"

--- a/exercises/practice/reverse-string/.meta/template.j2
+++ b/exercises/practice/reverse-string/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["value"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rna-transcription/.meta/template.j2
+++ b/exercises/practice/rna-transcription/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} <<< "{{ case["input"]["dna"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/roman-numerals/.meta/template.j2
+++ b/exercises/practice/roman-numerals/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["number"] }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rotational-cipher/.meta/template.j2
+++ b/exercises/practice/rotational-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v distance={{ case["input"]["shiftKey"] }} <<< "{{ case["input"]["text"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/run-length-encoding/.meta/template.j2
+++ b/exercises/practice/run-length-encoding/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["property"] }} {{ case["description"] }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {% if case["property"] in ["encode", "decode" ] %}
     run gawk -f {{ solution }} -v type={{ case["property"] }} <<< "{{ case["input"]["string"] }}"
     assert_success

--- a/exercises/practice/saddle-points/.meta/template.j2
+++ b/exercises/practice/saddle-points/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   expected=$(cat <<END_EXPECT
 {%- for expect in case["expected"] | sort(attribute="row,column") %}
 {{ expect["row"] }} {{ expect["column"] }}

--- a/exercises/practice/say/.meta/template.j2
+++ b/exercises/practice/say/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/scrabble-score/.meta/template.j2
+++ b/exercises/practice/scrabble-score/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< '{{ case["input"]["word"] }}'
 
     assert_success

--- a/exercises/practice/secret-handshake/.meta/template.j2
+++ b/exercises/practice/secret-handshake/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["number"] }}
     assert_success
     assert_output "{{ case["expected"] | join(",") }}"

--- a/exercises/practice/series/.meta/template.j2
+++ b/exercises/practice/series/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v len={{ case["input"]["sliceLength"] }} <<< "{{ case["input"]["series"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/sieve/.meta/template.j2
+++ b/exercises/practice/sieve/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< {{ case["input"]["limit"] }}
     assert_success
     assert_output "{{ case["expected"] | join(",") }}"

--- a/exercises/practice/space-age/.meta/template.j2
+++ b/exercises/practice/space-age/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["planet"] }} {{ case["input"]["seconds"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/spiral-matrix/.meta/template.j2
+++ b/exercises/practice/spiral-matrix/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<EOF
 {%- if case["expected"] %}
 {{ case["expected"] | map("join", " ") | join("\n") }}

--- a/exercises/practice/sum-of-multiples/.meta/template.j2
+++ b/exercises/practice/sum-of-multiples/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} -v limit={{ case["input"]["limit"] }} <<< "{{ case["input"]["factors"] | join(" ") }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/triangle/.meta/template.j2
+++ b/exercises/practice/triangle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}, {{ case["property"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run gawk -f {{ solution }} -v type={{ case["property"] }} <<< "{{ case["input"]["sides"] | join(" ") }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< '{{
         [
             case["input"]["bucketOne"],

--- a/exercises/practice/word-count/.meta/template.j2
+++ b/exercises/practice/word-count/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["sentence"] }}"
     assert_success
 {%- for word, count in case["expected"].items() %}

--- a/exercises/practice/wordy/.meta/template.j2
+++ b/exercises/practice/wordy/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ case["input"]["question"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/yacht/.meta/template.j2
+++ b/exercises/practice/yacht/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f {{ solution }} <<< "{{ (case["input"]["dice"] + [case["input"]["category"]]) | join(",") }}"
     assert_success
     assert_output {{ case["expected"] }}


### PR DESCRIPTION
Summarized changes:

```
» g diff | grep '^[+-][^+-]' | sort | uniq -c
      1 +        "cases": cases,
      1 -        "cases": list(enumerate(cases)),
     77 +{% for case in cases %}
     77 -{% for idx, case in cases %}
     55 -    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     21 -  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     55 +    {% if not loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     21 +  {% if not loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
```
